### PR TITLE
chore(config): add missing @type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
 	"author": "Robert Adamczewski <robert@adamczewski.me>",
 	"license": "MIT",
 	"devDependencies": {
+		"@types/jest": "^25.1.3",
+		"@types/node": "^13.7.7",
 		"gh-pages": "^2.2.0",
 		"jest": "^25.1.0",
 		"parcel-bundler": "^1.12.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,6 +1072,19 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^25.1.3":
+  version "25.1.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.1.3.tgz#9b0b5addebccfb631175870be8ba62182f1bc35a"
+  integrity sha512-jqargqzyJWgWAJCXX96LBGR/Ei7wQcZBvRv0PLEu9ZByMfcs23keUJrKv9FMR6YZf9YCbfqDqgmY+JUBsnqhrg==
+  dependencies:
+    jest-diff "^25.1.0"
+    pretty-format "^25.1.0"
+
+"@types/node@^13.7.7":
+  version "13.7.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.7.tgz#1628e6461ba8cc9b53196dfeaeec7b07fa6eea99"
+  integrity sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"


### PR DESCRIPTION
Polecam dodanie tych devDeps'ów, to podpowiadanie i ogarnianie składni dla `node` i dla `jest`.
Przydaje się zwłaszcza jeśli korzystamy z różnych **IDE**.